### PR TITLE
Hs screenshot bug

### DIFF
--- a/BYT.xcodeproj/project.pbxproj
+++ b/BYT.xcodeproj/project.pbxproj
@@ -48,11 +48,12 @@
 		473EA5D31E3E7E6100DD35C9 /* RobotoCondensed-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 473EA5C11E3E7E6100DD35C9 /* RobotoCondensed-Light.ttf */; };
 		473EA5D41E3E7E6100DD35C9 /* RobotoCondensed-LightItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 473EA5C21E3E7E6100DD35C9 /* RobotoCondensed-LightItalic.ttf */; };
 		473EA5D51E3E7E6100DD35C9 /* RobotoCondensed-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 473EA5C31E3E7E6100DD35C9 /* RobotoCondensed-Regular.ttf */; };
-    4786344D1E3E513600287661 /* FoaasFontManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4786344C1E3E513600287661 /* FoaasFontManager.swift */; };
+		4786344D1E3E513600287661 /* FoaasFontManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4786344C1E3E513600287661 /* FoaasFontManager.swift */; };
 		DE6658F71E3E805500513850 /* Extension + UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6658F61E3E805500513850 /* Extension + UIColor.swift */; };
 		DE6658F91E3E884800513850 /* ColorScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6658F81E3E884800513850 /* ColorScheme.swift */; };
 		DE6658FB1E3E8E6300513850 /* VersionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6658FA1E3E8E6300513850 /* VersionManager.swift */; };
 /* End PBXBuildFile section */
+
 /* Begin PBXFileReference section */
 		1498A2FF1E3E55E4003A3E5C /* Version.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Version.swift; path = Models/Version.swift; sourceTree = "<group>"; };
 		1498A3021E3E55F0003A3E5C /* ColorManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ColorManager.swift; path = Managers/ColorManager.swift; sourceTree = "<group>"; };
@@ -101,7 +102,6 @@
 		DE6658F61E3E805500513850 /* Extension + UIColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Extension + UIColor.swift"; path = "Models/Extension + UIColor.swift"; sourceTree = "<group>"; };
 		DE6658F81E3E884800513850 /* ColorScheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ColorScheme.swift; path = Models/ColorScheme.swift; sourceTree = "<group>"; };
 		DE6658FA1E3E8E6300513850 /* VersionManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VersionManager.swift; sourceTree = "<group>"; };
-
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -272,6 +272,7 @@
 				TargetAttributes = {
 					14CFEBE51E3430C600BD46CF = {
 						CreatedOnToolsVersion = 8.2.1;
+						DevelopmentTeam = R7DWEPXN5Y;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -313,7 +314,6 @@
 				473EA5D31E3E7E6100DD35C9 /* RobotoCondensed-Light.ttf in Resources */,
 				473EA5CC1E3E7E6100DD35C9 /* Roboto-MediumItalic.ttf in Resources */,
 				473EA5C51E3E7E6100DD35C9 /* Roboto-BlackItalic.ttf in Resources */,
-				A7059A0A1E37E20800A09796 /* FoaasSettingsMenuView.xib in Resources */,
 				473EA5C81E3E7E6100DD35C9 /* Roboto-Italic.ttf in Resources */,
 				473EA5D01E3E7E6100DD35C9 /* RobotoCondensed-Bold.ttf in Resources */,
 				473EA5C71E3E7E6100DD35C9 /* Roboto-BoldItalic.ttf in Resources */,
@@ -468,7 +468,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = R7DWEPXN5Y;
 				INFOPLIST_FILE = "$(SRCROOT)/BYT/Supporting Files/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -483,7 +483,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = R7DWEPXN5Y;
 				INFOPLIST_FILE = "$(SRCROOT)/BYT/Supporting Files/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/BYT/View Controllers/FoaasViewController.swift
+++ b/BYT/View Controllers/FoaasViewController.swift
@@ -262,9 +262,9 @@ class FoaasViewController: UIViewController, FoaasViewDelegate, FoaasSettingMenu
     
     func camerarollButtonTapped() {
         print("cameraroll button tapped")
-        guard let vaidImage = getScreenShotImage(view: self.view) else { return }
+        guard let validImage = getScreenShotImage(view: self.view) else { return }
         //https://developer.apple.com/reference/uikit/1619125-uiimagewritetosavedphotosalbum
-        UIImageWriteToSavedPhotosAlbum(vaidImage, self, #selector(createScreenShotCompletion(image: didFinishSavingWithError: contextInfo:)), nil)
+        UIImageWriteToSavedPhotosAlbum(validImage, self, #selector(createScreenShotCompletion(image: didFinishSavingWithError: contextInfo:)), nil)
     }
     
     func shareButtonTapped() {

--- a/BYT/View Controllers/FoaasViewController.swift
+++ b/BYT/View Controllers/FoaasViewController.swift
@@ -265,6 +265,10 @@ class FoaasViewController: UIViewController, FoaasViewDelegate, FoaasSettingMenu
         guard let validImage = getScreenShotImage(view: self.view) else { return }
         //https://developer.apple.com/reference/uikit/1619125-uiimagewritetosavedphotosalbum
         UIImageWriteToSavedPhotosAlbum(validImage, self, #selector(createScreenShotCompletion(image: didFinishSavingWithError: contextInfo:)), nil)
+        
+        //after the screenshot is saved, the settings menu will animate back into it's original position (show: true).
+        //this will give the false impression that the screenshot includes the settings menu because of how quickly it occurs.
+        animateSettingsMenu(show: true, duration: 0.8, dampening: 0.7, springVelocity: 7)
     }
     
     func shareButtonTapped() {
@@ -298,6 +302,10 @@ class FoaasViewController: UIViewController, FoaasViewDelegate, FoaasSettingMenu
     ///Get current screenshot
     func getScreenShotImage(view: UIView) -> UIImage? {
         //https://developer.apple.com/reference/uikit/1623912-uigraphicsbeginimagecontextwitho
+        
+        //shortly before the graphics context for the view is determined, the settings menu will animate down (show: false)
+        animateSettingsMenu(show: false, duration: 0.1)
+        
         UIGraphicsBeginImageContextWithOptions(view.bounds.size, true, view.layer.contentsScale)
         guard let context = UIGraphicsGetCurrentContext() else{
             return nil

--- a/BYT/View Controllers/FoaasViewController.swift
+++ b/BYT/View Controllers/FoaasViewController.swift
@@ -268,7 +268,7 @@ class FoaasViewController: UIViewController, FoaasViewDelegate, FoaasSettingMenu
         
         //after the screenshot is saved, the settings menu will animate back into it's original position (show: true).
         //this will give the false impression that the screenshot includes the settings menu because of how quickly it occurs.
-        animateSettingsMenu(show: true, duration: 0.8, dampening: 0.7, springVelocity: 7)
+        animateSettingsMenu(show: true, duration: 0.1)
     }
     
     func shareButtonTapped() {


### PR DESCRIPTION
-Screenshot bug resolved by using animateSettingsMenu call.

-First call occurs immediately before configuring the graphics context of the FoaasViewController (within the getScreenShotImage(view:) function call). This animates the settings menu down.

-The second call is occurring after the screenshot is saved to the Photos album and animates the settings menu back up to where it originally was before tapping the Camera Roll button.

- I've attached a ZIP of the screen recording I tested the animation with, for reference.

[Screenshot Recording.zip](https://github.com/AccessLite/BYT-Golden/files/745748/Screenshot.Recording.zip)

